### PR TITLE
Recreate bug in iOS

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,4 +1,4 @@
 //= link_tree ../images
 //= link_directory ../stylesheets .css
 //= link_tree ../../javascript .js
-//= link_tree ../../../vendor/javascript .js
+

--- a/app/controllers/modals_controller.rb
+++ b/app/controllers/modals_controller.rb
@@ -1,0 +1,13 @@
+class ModalsController < ApplicationController
+  def new
+    if params[:redirect]
+      redirect_to navigation_path
+    end
+  end
+
+  def show
+  end
+
+  def replace
+  end
+end

--- a/app/views/application/index.html.erb
+++ b/app/views/application/index.html.erb
@@ -1,1 +1,9 @@
 <h1>application#index</h1>
+ <ul>
+    <li>Click to get a
+        <%= link_to "Modal", new_modal_path %>
+    </li>
+    <li>Click to get a modal and redirect to
+        <%= link_to "Navigation Path", new_modal_path(redirect: true) %>
+    </li>
+</ul>

--- a/app/views/application/navigation.html.erb
+++ b/app/views/application/navigation.html.erb
@@ -1,1 +1,3 @@
 <h1>application#navigation</h1>
+<p>This is the view we will redirect to</p>
+<p>BUG: If you are seeing this view within the "modal" view controller</p>

--- a/app/views/modals/new.html.erb
+++ b/app/views/modals/new.html.erb
@@ -1,0 +1,1 @@
+<h1>This is a Modal View</h1>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,14 @@ Rails.application.routes.draw do
 
   get "navigation" => "application#navigation"
 
+  get "modal" => "application#modal"
+
+  resource :modal, only: %i[new show] do
+    collection do
+      get :replace
+    end
+  end
+
   # Defines the root path route ("/")
   root "application#index"
 end

--- a/ios/path-configuration.json
+++ b/ios/path-configuration.json
@@ -31,5 +31,13 @@
         "presentation": "modal"
       }
     },
+    {
+      "patterns": [
+        "/modal"
+      ],
+      "properties": {
+        "presentation": "modal"
+      }
+    }
   ]
 }


### PR DESCRIPTION
So there seem to be 3 instances of this bug:

* On the first instance we click the redirect link: path `/modal` is handled to display modal however when a redirect happens  the redirect will display in the modal when `/navigation` is supposed to be handled in the normal view stack. 
* Followed by the first click:  if clicked again that is when the behavior of the redirect of `/navigation` replaces the whole stack and navigation is "broken" 

https://github.com/seanpdoyle/turbo_native_bug_template/assets/48501079/3f2c9e63-294b-4466-a5b5-f8914211b012

* The third instance is a bit of an outlier: click to view modal normally (everything as expected), dismiss modal, then click the navigation redirect link and we have the same effect of replacing the view stack. 

https://github.com/seanpdoyle/turbo_native_bug_template/assets/48501079/a854ac0b-0de2-4bc4-b1ef-324b5d8c8646


